### PR TITLE
Add missing python3-libselinux dependency

### DIFF
--- a/roles/bootstrap-packages/tasks/main.yml
+++ b/roles/bootstrap-packages/tasks/main.yml
@@ -16,6 +16,7 @@
     - redhat-rpm-config
     - rpmdevtools
     - libselinux-python
+    - python3-libselinux
 
 - name: Create mock group
   become: yes


### PR DESCRIPTION
W/o that package, the task bootstrap-packages : drop in the templated
version of projects.ini fails with
Aborting, target uses selinux but python bindings (libselinux-python)
aren't installed!

Signed-off-by: Bogdan Dobrelya <bogdando@mail.ru>